### PR TITLE
Use more generic argument to set different boot mounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,13 +107,13 @@ entries for any other mounts:
 
 ```yaml
 mounts_boot:
-  - uuid: "88f0236b-620a-456e-a4a6-1b5c84996b5c"
+  - device: "UUID=88f0236b-620a-456e-a4a6-1b5c84996b5c"
     mount_point: "/"
     type: "ext4"
     options: "errors=remount-ro"
     dump: 0
     pass: 1
-  - uuid: "b8d210eb-d186-405f-bc42-a55cbe069a27"
+  - device: "UUID=b8d210eb-d186-405f-bc42-a55cbe069a27"
     mount_point: "none"
     type: "swap"
     options: "sw"

--- a/templates/fstab.j2
+++ b/templates/fstab.j2
@@ -12,7 +12,7 @@
 
 ###### Boot Mounts - Mount points necessary for the system to boot
 {% for mount in mounts_boot %}
-UUID={{ mount.uuid }} {{ mount.mount_point }} {{ mount.type }} {{ mount.options }} {{ mount.dump }} {{ mount.pass }}
+{{ mount.device }} {{ mount.mount_point }} {{ mount.type }} {{ mount.options }} {{ mount.dump }} {{ mount.pass }}
 {% endfor %}
 
 {% if mounts_cryptdisks is defined %}


### PR DESCRIPTION
Such as: UUID, PARTUUID, LABEL, proc